### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.20.0
 PyLaTeX==1.3.0
-python-nmap
+python3-nmap
 qrcode==6.1
 Flask==1.0.2
 colorama==0.4.1


### PR DESCRIPTION
Should take care of Issue #199 
Initial setup fails when installing packages from requirements.txt and throws "ERROR: Failed building wheel for python-nmap"

- **Warning**: It's my first pull request.  Let me know if I should have done something differently.

- **Root cause**: https://github.com/pypa/pip/issues/8368
    

-  #**Resolution**: Changed python-nmap to python3-nmap in file: requirements.txt
