### PR TITLE
[bugfix] `nmap` distribution not found

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ qrcode
 Flask
 colorama
 Flask_Login
-nmap
+python3-nmap
 python-secrets

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ qrcode
 Flask
 colorama
 Flask_Login
-python3-nmap
+python-nmap
 python-secrets


### PR DESCRIPTION
encountering an error when trying to install the `nmap` package using pip.

refactor `nmap` to `python3-nmap`


fixes: 
```
ERROR: Could not find a version that satisfies the requirement nmap (from versions: none)
ERROR: No matching distribution found for nmap
```