### PR TITLE
fixed incorrect python-nmap requirement in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pipenv install qrcode
 RUN pipenv install Flask
 RUN pipenv install colorama
 RUN pipenv install Flask_Login
-RUN pipenv install nmap
+RUN pipenv install python-nmap
 #RUN pipenv install python-secrets
 
 COPY . .


### PR DESCRIPTION
The dockerfile wouldn't build because of the incorrect `nmap` dependency. I've updated it to match the `python-nmap` version found in requirements.txt.